### PR TITLE
Datepicker

### DIFF
--- a/src/components/common/Datepicker.jsx
+++ b/src/components/common/Datepicker.jsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Input } from '@chakra-ui/react';
+import Separator from '../../assets/icons/Datepicker_Separator.svg';
+
+/**
+ * Datepicker 컴포넌트
+ *
+ * Props:
+ * - register: react-hook-form의 register 함수
+ * - min: 최소 날짜 (YYYY-MM-DD 형식)
+ * - max: 최대 날짜 (YYYY-MM-DD 형식)
+ * - required: 필수 입력 여부
+ * - disabled: 비활성화 여부
+ */
+
+const Datepicker = ({
+  register,
+  min,
+  max,
+  required = false,
+  disabled = false,
+}) => {
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  // 시작일 변경 → 종료일 최소값 설정
+  const handleStartDateChange = (e) => {
+    const value = e.target.value;
+    setStartDate(value);
+  };
+
+  // 종료일 변경 → 시작일 최대값 설정
+  const handleEndDateChange = (e) => {
+    const value = e.target.value;
+    setEndDate(value);
+  };
+
+  return (
+    <SContainer>
+      <SDateInputWrapper>
+        <SDateInput
+          as={Input}
+          type='date'
+          min={min}
+          max={endDate || max}
+          required={required}
+          disabled={disabled}
+          {...register('startDate', {
+            required,
+            onChange: handleStartDateChange,
+          })}
+        />
+      </SDateInputWrapper>
+
+      <SDivider>
+        <img src={Separator} alt='separator' />
+      </SDivider>
+
+      <SDateInputWrapper>
+        <SDateInput
+          as={Input}
+          type='date'
+          min={startDate || min}
+          max={max}
+          required={required}
+          disabled={disabled}
+          {...register('endDate', {
+            required,
+            onChange: handleEndDateChange,
+          })}
+        />
+      </SDateInputWrapper>
+    </SContainer>
+  );
+};
+
+const SContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: auto;
+  max-width: 22.375rem;
+`;
+
+const SDateInputWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  align-self: stretch;
+
+  width: auto;
+  height: var(--sizes-12, 3rem);
+  padding: var(--spacing-1, 0.2rem) var(--spacing-1, 0.2rem);
+
+  border: var(--borders-sm, 1px) solid var(--colors-border-default, #e4e4e7);
+  border-radius: var(--radii-Semantic_tokens-l2, 0.25rem);
+`;
+
+const SDateInput = styled.input`
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  justify-content: space-between;
+
+  width: 9.25rem;
+  padding-top: var(--spacing-2, 0.2rem);
+  gap: var(--spacing-0-5, 0.1rem);
+
+  border-radius: 0.5rem;
+
+  &:focus {
+    outline: none;
+    border-color: var(--colors-border-focused, #3182ce);
+    box-shadow: 0 0 0 3px var(--colors-focus-ring, rgba(49, 130, 206, 0.1));
+  }
+
+  &:disabled {
+    background-color: var(--colors-bg-muted, #f7fafc);
+    color: var(--colors-fg-muted, #a0aec0);
+    cursor: not-allowed;
+  }
+
+  &::-webkit-calendar-picker-indicator {
+    cursor: pointer;
+  }
+`;
+
+const SDivider = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    stroke-width: 1px;
+    stroke: var(--colors-border-default, #e4e4e7);
+  }
+`;
+
+export default Datepicker;


### PR DESCRIPTION
## 🔎 What is this PR?

> 퍼블리싱 관련 PR은 Figma GUI를 첨부해 주세요.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/800583ed-66bb-44e7-b58c-e56f966d32c4" />

<br/>

## ✨ Changes
1. Chakra UI Input 컴포넌트
2. **날짜 선택 시 최대/최소 값 자동설정**
   - 시작일 선택 → 종료일 최소값
   - 종료일 선택 → 시작일 최대값
3. **Props** : react-hook-form의 `register` 함수, `required`, `disabled` 등
4. 가능한 **CSS 변수**를 활용하려고 하였음
<br/>

## 📷 Result
>스크린샷, 시연 영상 등
<img width="500" alt="image" src="https://github.com/user-attachments/assets/efc0109f-4edb-4364-b131-1d6ff9eaeba9" />


<br/>

## 💬 To. Reviewer
> 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
- disabled 상태일 때 스타일은 따로 GUI가 없어서, 피그마에 올려두신 토큰 보고 제가 CSS 변수로 구현했습니다.
- 그런데 `input type="date"`는 OS 별로 네이티브 UI가 다 달라서 `background-color` 나 `color` 같은 경우는 OS 따라 되기도 하고 안 되기도 하는 것 같습니다. 저 같은 경우는 disabled 상태일 때 `background-color` 와 `color`를 Window OS 에서 확인했는데, 혹시 Mac 사용자 분이 계시다면 이 부분 어떻게 보이는지 확인 부탁드립니다!
<br/>
<br/>

